### PR TITLE
Conda recipe improvements

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,6 +31,10 @@ requirements:
     - klb
 
 test:
+
+  source_files:
+    - test
+
   imports:
     - pyklb
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   path: ../
 
 build:
-  number: 0
+  number: 1
   
   # This must be built with the --numpy option, for example:
   # conda build --numpy=1.10 conda-recipe

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,6 +20,8 @@ build:
 
 requirements:
   build:
+    - gxx_linux-64 # [linux]
+  host:
     - python {{PY_VER}}*
     - numpy {{NPY_VER}}*
     - cython

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -1,2 +1,2 @@
-cd ${SRC_DIR}/test
+cd test
 python test_pyklb.py


### PR DESCRIPTION
This updates the conda recipe to work with newer version of conda-build, and also uses Anaconda's gcc package, rather than the system gcc.

I built the resulting `pyklb` package.  On Mac and Linux, you can install it via:

```
conda install -c ilastik-forge pyklb
```

Related: I also updated the conda recipe for `klb` itself.  See here:

https://bitbucket.org/fernandoamat/keller-lab-block-filetype/pull-requests/2/update-conda-recipe/diff
