### PR TITLE
Pin the dependencies to before Jul 2, 2021.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["cmake", "cython", "numpy", "setuptools", "scikit-build", "wheel"]
+requires = ["cmake==3.20.4", "cython==0.29.23", "numpy==1.21.0", "setuptools==57.0.0", "scikit-build==0.11.1", "wheel"]


### PR DESCRIPTION
Hi @bhoeckendorf,

I'm submitting this change as per https://github.com/bhoeckendorf/pyklb/issues/11#issuecomment-1910113396. It would be nice to get this merged, so that [installation](https://github.com/bhoeckendorf/pyklb?tab=readme-ov-file#installation) would *just work* (at least in Python 3.7 through 3.9).

Thanks again, @lagru! :heart: 